### PR TITLE
Fixed result of `jq` is being discarded

### DIFF
--- a/godaddy.sh
+++ b/godaddy.sh
@@ -84,12 +84,12 @@ if [ "$(cat ${CachedIP} 2>/dev/null)" != "${PublicIP}" ];then
   Check=$(${Curl} -kLsH"Authorization: sso-key ${Key}:${Secret}" \
   -H"Content-type: application/json" \
   https://api.godaddy.com/v1/domains/${Domain}/records/${Type}/${Name} \
-  2>/dev/null|jq -r '.[0].data'>/dev/null)
+  2>/dev/null|jq -r '.[0].data')
   if [ $? -eq 0 ] && [ "${Check}" = "${PublicIP}" ];then
     echo -n ${Check}>${CachedIP}
     echo -e "unchanged!\nCurrent 'Public IP' matches 'GoDaddy' records. No update required!"
   else
-    echo -en "changed!\nUpdating '${Domain}'..."
+    echo -en "changed!\nUpdating '${Domain}' ${Check} -> ${PublicIP}..."
     Update=$(${Curl} -kLsXPUT -H"Authorization: sso-key ${Key}:${Secret}" \
     -H"Content-type: application/json" \
     https://api.godaddy.com/v1/domains/${Domain}/records/${Type}/${Name} \


### PR DESCRIPTION
Steps to reproduce:
 * Fill in the correct values for `Key`, `Secret`, `Domain` and `Name` variables
 * Run the script
 * Script will run and update GoDaddy records. 
 * Delete ` /tmp/current_ip` file
 * Run again before the IP changes. 
Outcome: 
 * Script will always fall into changed! on line 92, and will update GoDaddy.
Expected:
 * The IP is unchanged so the update shouldn't happen.

This patch fixes the problem by not sending `jq` output to `/dev/null`